### PR TITLE
Use button element for start/stop buttons

### DIFF
--- a/src/daemon/public/index.html
+++ b/src/daemon/public/index.html
@@ -25,12 +25,12 @@
             <span class="status">
               <small>{{status}}</small>
             </span>
-            <span class="start {{status}}" data-id="{{id}}">
+            <button class="start {{status}}" data-id="{{id}}">
               <small>start</small>
-            </span>
-            <span class="stop {{status}}" data-id="{{id}}">
+            </button>
+            <button class="stop {{status}}" data-id="{{id}}">
               <small>stop</small>
-            </span>
+            </button>
           </div>
 
         </div>

--- a/src/daemon/public/style.css
+++ b/src/daemon/public/style.css
@@ -1,5 +1,9 @@
 /* Available status: running, stopping, stopped, crashed, sleeping */
 
+html, button {
+  font-family: sans-serif;
+}
+
 /* hide */
 .running.start,
 .stopping.start,
@@ -7,15 +11,6 @@
 .crashed.stop,
 .sleeping.stop {
   display: none;
-}
-
-/* show */
-.running.stop,
-.stopping.stop,
-.stopped.start,
-.crashed.start,
-.sleeping.start {
-  display: table-cell;
 }
 
 body {
@@ -40,10 +35,6 @@ code {
   padding: 4px;
 }
 
-small {
-  color: #999;
-}
-
 .monitor {
   width: 280px;
   margin: 0;
@@ -60,19 +51,33 @@ small {
 }
 
 .details {
-  display:table;
-  width:100%;
+  overflow: hidden;
   margin-top: 4px;
 }
 
-span {
-  display: table-cell;
-  width: 50%;
+.status {
+  color: #999;
+  float: left;
 }
 
-span.start, span.stop {
+/* Start-stop buttons */
+.start, .stop {
+  float: right;
   cursor: pointer;
   text-align: right;
+  border: 0;
+  padding: 0;
+  outline: 0;
+  background: transparent;
+  font-size: 1em;
+  color: #999;
+}
+
+.start:hover,
+.start:focus,
+.stop:hover,
+.stop:focus {
+  color: #111;
 }
 
 footer a {


### PR DESCRIPTION
This changes start/stop buttons to `<button>` elements instead of `<span>`.

This makes keyboard navigation available via tabbing to the start/stop buttons, or via extensions like [VimFx](https://addons.mozilla.org/en-US/firefox/addon/vimfx/) (pictured) or vimium.

This PR doesn't alter the appearance in any way.

![pasted_image_6_21_15__1_38_am](https://cloud.githubusercontent.com/assets/74385/8268373/46f304b2-17b6-11e5-8ce9-6456c618b4b4.jpg)
