### PR TITLE
Add a charset meta tag

### DIFF
--- a/src/daemon/public/index.html
+++ b/src/daemon/public/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>hotel</title>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
   </head>


### PR DESCRIPTION
For an HTML document to be valid, it has to have at least a doctype (`<!doctype html>`) and a `<meta charset>` tag.

This adds the latter. Typically it's not needed, but if the user has projects with non-latin chåraçters in them, it may end up rendering strange. Better safe than sorry.