### PR TITLE
Print a warning when adding without -o

### DIFF
--- a/src/actions/servers.js
+++ b/src/actions/servers.js
@@ -48,6 +48,11 @@ function add (cmd, opts) {
   fs.writeFileSync(file, data)
 
   console.log(`  Added  http://localhost:${conf.port}/${id}`)
+
+  if (!obj.out) {
+    console.log(`  Warn   No log file specified. Output will be discarded.`)
+    console.log(`         Use '-o log.txt' to specify a logfile.`)
+  }
 }
 
 function rm (name) {


### PR DESCRIPTION
Expecting logfiles from a long-running process wouldn't be out of the ordinary.

This prints a warning when using `hotel add` without `-o`.

![pasted_image_6_21_15__2_04_am](https://cloud.githubusercontent.com/assets/74385/8268486/f0a96a5c-17b9-11e5-96c0-7f30805fd60c.jpg)
