### PR TITLE
Move mocha options to mocha.opts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "prepublish": "npm test",
-    "test": "npm run build && npm run standard && mocha --compilers js:babel/register",
+    "test": "npm run build && npm run standard && mocha",
     "install": "node bin/install",
     "uninstall": "node bin/uninstall",
     "standard": " standard bin src/**/*.js test/**/*.js",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--compilers js:babel/register


### PR DESCRIPTION
This allows you to re-invoke tests by typing `mocha`.

You can use `npm test`, but that will run the builder and the linter too, which you may not want.