### PR TITLE
Implement 'hotel open'

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -7,6 +7,7 @@ var sudoBlock = require('sudo-block')
 var servers = require('../lib/actions/servers')
 var daemon = require('../lib/actions/daemon')
 var autostart = require('../lib/actions/autostart')
+var opener = require('../lib/actions/opener')
 var pkg = require('../package.json')
 
 sudoBlock('\n  Should not be run as root, please retry without sudo.\n')
@@ -24,6 +25,7 @@ var yargs = require('yargs')
   .command('stop', 'Stop daemon')
   .command('autostart', 'Create autostart script')
   .command('rm-autostart', 'Remove autostart script')
+  .command('open', 'Open hotel in your browser')
   .example('$0 add nodemon')
   .example('$0 add -o app.log \'serve -p $PORT\'')
   .example('$0 add -n app \'serve -p $PORT\'')
@@ -59,6 +61,12 @@ function run (cb) {
   if (_[0] === 'stop') {
     // Asynchronous command
     daemon.stop(cb)
+    return
+  }
+
+  if (_[0] === 'open') {
+    // Asynchronous command
+    opener.open(cb)
     return
   }
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "get-port": "^1.0.0",
     "got": "^2.9.2",
     "mkdirp": "^0.5.0",
+    "opener": "^1.4.1",
     "respawn-group": "^1.0.1",
     "socket.io": "^1.3.5",
     "sudo-block": "^1.2.0",

--- a/src/actions/opener.js
+++ b/src/actions/opener.js
@@ -1,0 +1,32 @@
+const opener = require('opener')
+const conf = require('../conf')
+const net = require('net')
+
+module.exports = {
+  open
+}
+
+function open (cb) {
+  const url = `http://localhost:${conf.port}`
+  ensureAvailable(conf.port, (err) => {
+    if (err) {
+      console.log(`  Error   Can't connect to hotel daemon`)
+      console.log(`          Use 'hotel start' to start the service`)
+      console.log('')
+      process.exit(1)
+    }
+
+    const proc = opener(url)
+    proc.unref()
+    cb()
+  })
+}
+
+function ensureAvailable (port, cb) {
+  const client = net.connect({ port }, () => {
+    client.destroy()
+    cb()
+  }).on('error', err => {
+    cb(err)
+  })
+}


### PR DESCRIPTION
This will open `http://localhost:2000` in your local browser. It respects the config file, but always uses `localhost` (in case you set host to 0.0.0.0).

osx, linux and windows supported.