### PR TITLE
Make timeouts configurable

### DIFF
--- a/src/conf.js
+++ b/src/conf.js
@@ -12,7 +12,8 @@ let file = untildify('~/.hotel/conf.json')
 // Defaults
 let defaults = {
   port: 2000,
-  host: '127.0.0.1'
+  host: '127.0.0.1',
+  timeout: 5000
 }
 
 // Create file it it doesn't exist

--- a/src/daemon/router.js
+++ b/src/daemon/router.js
@@ -1,4 +1,5 @@
 let net = require('net')
+let conf = require('../conf')
 let express = require('express')
 let pkg = require('../../package.json')
 
@@ -33,7 +34,8 @@ module.exports = function (servers) {
     // Redirect when server is reachable
     let port = servers.get(id).env.PORT
     let hostname = req.hostname
-    let counter = 0
+    let timeout = conf.timeout
+    let start = new Date()
 
     function forward () {
       // On connect, destroy client
@@ -49,9 +51,11 @@ module.exports = function (servers) {
       // On error, increment counter
       // Give up after the 5th attempt
       function handleError () {
-        if (++counter === 5) {
+        if (new Date() - start > timeout) {
           clearInterval(intervalId)
-          res.status(502).send(`Can't connect to server on port ${port} (retry or check logs).`)
+          res.status(502).send(
+            `Can't connect to server on port ${port}, ` +
+            `timeout of ${timeout}ms exceeded. Retry or check logs.`)
         }
       }
 


### PR DESCRIPTION
There's no mention in the error message of the 5 second timeout. This fixes that.

> Can't connect to server on port 84297, timeout of 5000ms exceeded. Retry or check logs.

This also adds the `timeout: 5000` configuration option. In my experience, 5secs is way too low for something like a Rails app.