### PR TITLE
Fix server port mismatch

### DIFF
--- a/src/daemon/server-group.js
+++ b/src/daemon/server-group.js
@@ -32,13 +32,13 @@ function addServer (group, file) {
   let server = JSON.parse(fs.readFileSync(file, 'utf8'))
   let id = getId(file)
   getPort().then(port => {
-    util.log(`Add server id: ${id} cmd: ${server.cmd} port: ${port}`)
-
     process.env.PORT = port
     let opts = {
       cwd: server.cwd,
       env: Object.assign({}, process.env, server.env)
     }
+
+    util.log(`Add server id: ${id} cmd: ${opts.cmd} port: ${opts.env.PORT}`)
 
     let logFile
     if (server.out) {


### PR DESCRIPTION
Currently, if a port is specified in the server config, it's not properly logged.

```
4 Mar 21:26:50 - Add server id: test cmd: php -S 192.168.0.12:8888 port: 28461
```

:kissing: 