### PR TITLE
Fix http proxy refresh crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ hotel add "cmd -p %PORT%" # Windows
 ~/.hotel/servers/<app-name>.json
 ```
 
+### Self-signed certificate
+
+To use self-signed certificate, please put the cert and key to `~/.hotel/`, and add `key_path` and `cert_path` to `~/.hotel.conf.json`.
+
+### Example
+```json
+{
+  "port": 2000,
+  "host": "127.0.0.1",
+  "timeout": 5000,
+  "tld": "dev",
+  "key_path": ".hotel/hotel.key",
+  "cert_path": ".hotel/hotel.crt"
+}
+```
+
 ## Third-party tools
 
 * [Hotel Clerk](https://github.com/therealklanni/hotel-clerk) OS X menubar

--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -24,8 +24,8 @@ const {
 const home_path = HOME || HOMEPATH || USERPROFILE
 
 if (conf.key_path && conf.cert_path) {
-  ssl.key = fs.readFileSync(path.join(home_path, conf.key_path))
-  ssl.cert = fs.readFileSync(path.join(home_path, conf.cert_path))
+  ssl.key = fs.readFileSync(path.resolve(home_path, conf.key_path))
+  ssl.cert = fs.readFileSync(path.resolve(home_path, conf.cert_path))
 } else {
   ssl.key = fs.readFileSync(path.join(__dirname, 'certs/server.key'))
   ssl.cert = fs.readFileSync(path.join(__dirname, 'certs/server.crt'))

--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -40,6 +40,16 @@ const proxy = httpProxy.createServer({
   ws: true
 })
 
+proxy.on('proxyReq', (proxyReq, req) => {
+  req._proxyReq = proxyReq
+})
+
+proxy.on('error', (err, req) => {
+  if (req.socket.destroyed && err.code === 'ECONNRESET') {
+    req._proxyReq.abort()
+  }
+})
+
 proxy.listen(conf.port + 1)
 
 server.listen(conf.port, conf.host, function () {

--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -15,15 +15,28 @@ exitHook(() => {
   pidFile.remove()
 })
 
+const ssl = {}
+const {
+  HOME,
+  HOMEPATH,
+  USERPROFILE
+} = process.env
+const home_path = HOME || HOMEPATH || USERPROFILE
+
+if (conf.key_path && conf.cert_path) {
+  ssl.key = fs.readFileSync(path.join(home_path, conf.key_path))
+  ssl.cert = fs.readFileSync(path.join(home_path, conf.cert_path))
+} else {
+  ssl.key = fs.readFileSync(path.join(__dirname, 'certs/server.key'))
+  ssl.cert = fs.readFileSync(path.join(__dirname, 'certs/server.crt'))
+}
+
 const proxy = httpProxy.createServer({
   target: {
     host: '127.0.0.1',
     port: conf.port
   },
-  ssl: {
-    key: fs.readFileSync(path.join(__dirname, 'certs/server.key')),
-    cert: fs.readFileSync(path.join(__dirname, 'certs/server.crt'))
-  },
+  ssl,
   ws: true
 })
 


### PR DESCRIPTION
Hotel will crash when refresh quickly. This is a patch for it.

FYI:
https://github.com/nodejitsu/node-http-proxy/issues/813#issuecomment-161266263