### PR TITLE
fix http-proxy's crash when refresh quickly

### DIFF
--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -28,6 +28,16 @@ const proxy = httpProxy.createServer({
   ws: true
 })
 
+proxy.on('proxyReq', (proxyReq, req) => {
+  req._proxyReq = proxyReq
+})
+
+proxy.on('error', (err, req) => {
+  if (req.socket.destroyed && err.code === 'ECONNRESET') {
+    req._proxyReq.abort()
+  }
+})
+
 proxy.listen(conf.port + 1)
 
 server.listen(conf.port, conf.host, function () {


### PR DESCRIPTION
Hotel will crash when refresh quickly. This is a patch for it.

FYI:
https://github.com/nodejitsu/node-http-proxy/issues/813#issuecomment-161266263