### PR TITLE
Preliminary support for proxies based on http_proxy env variable

### DIFF
--- a/src/daemon/views/proxy-pac.js
+++ b/src/daemon/views/proxy-pac.js
@@ -3,7 +3,19 @@ const conf = require('../../conf')
 // Tells the browser to proxy *.dev URLs to hotel
 module.exports =
 `function FindProxyForURL (url, host) {
-  if (dnsDomainIs(host, '.${conf.tld}')) return 'PROXY 127.0.0.1:${conf.port}'
-  return 'DIRECT'
+  var proxy = '${process.env.http_proxy}';
+  if (dnsDomainIs(host, '.${conf.tld}'))
+    return 'PROXY 127.0.0.1:${conf.port}'
+  if (proxy != null && proxy.trim() != "") {
+      if (host == "127.0.0.1"
+        || host == "localhost"
+        || isInNet(dnsResolve(host), "10.0.0.0", "255.0.0.0")
+        || isInNet(dnsResolve(host), "192.168.0.0", "255.255.0.0")) {
+        return 'DIRECT'
+      }
+      return 'PROXY ' + proxy
+  } else {
+    return 'DIRECT'
+  }
 }
 `


### PR DESCRIPTION
Update the proxy.pac to use a proxy if the http_proxy environment variable is present. Bypasses the proxy for standard private IP blocks (10.0.0.0/8 and 192.168.0.0/16).

Definitely open to feedback on this so let me know if you see any obvious places for improvement.