### PR TITLE
Support coloured ANSI output

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "exec": "babel-node",
+  "exec": "node_modules/.bin/babel-node",
   "ignore": [
     "src/client",
     "src/daemon/public"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/typicode/hotel",
   "dependencies": {
+    "ansi_up": "^1.3.0",
     "body-parser": "^1.14.2",
     "chokidar": "^1.2.0",
     "connect-sse": "^1.2.0",

--- a/src/client/components/List.vue
+++ b/src/client/components/List.vue
@@ -46,7 +46,12 @@
     <p><em>Use hotel command-line to add servers</em></p>
   </div>
 
-  <Output class="output" v-show="outputId"><Output>
+  <Output 
+    v-bind:class="lightsOn() ? 'output white' : 'output black'"
+    v-show="outputId"
+    :lights="lightsOn()"
+  >
+  <Output>
 </template>
 
 <script>
@@ -55,6 +60,12 @@ import * as actions from '../actions'
 
 export default {
   components: { Output },
+
+  data() {
+    return {
+      lights: false
+    }
+  },
 
   vuex: {
     getters: {
@@ -83,6 +94,17 @@ export default {
       this.isRunning(status)
         ? this.stopMonitor(id)
         : this.startMonitor(id)
+    },
+
+    lightsOn() {
+      return this.lights;
+    },
+
+  },
+
+  events: {
+    'toggle-lights': function() {
+      this.lights = !this.lights;
     }
   }
 }

--- a/src/client/components/Output.vue
+++ b/src/client/components/Output.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-on:scroll="onScroll">
     <div v-for="item in output" track-by="_uid">
-      {{ item.line }}
+      {{{ item.line }}}
     </div>
   </div>
 </template>

--- a/src/client/components/Output.vue
+++ b/src/client/components/Output.vue
@@ -1,13 +1,31 @@
 <template>
-  <div v-on:scroll="onScroll">
-    <div v-for="item in output" track-by="_uid">
-      {{{ item.line }}}
+  <div>
+    <div class="toggle-background">
+      <a
+        class="toggle"
+        v-bind:class="lightsOn() ? 'on' : 'off'"
+        v-on:click.prevent="toggleLights()"
+      >
+        <i
+          class="fa"
+          v-bind:class="lightsOn() ? 'fa-toggle-on' : 'fa-toggle-off'"
+        >
+        </i>
+      </a>
+    </div>
+
+    <div v-on:scroll="onScroll" v-bind:class="lightsOn() ? 'white' : 'black'">
+      <div v-for="item in output" track-by="_uid">
+        {{{ item.line }}}
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 export default {
+  props: ['lights'],
+
   data() {
     return {
       scroll: true,
@@ -36,6 +54,14 @@ export default {
     onScroll(event) {
       var element = event.target
       this.scroll = element.scrollHeight - element.scrollTop === element.clientHeight
+    },
+
+    lightsOn() {
+      return this.lights;
+    },
+
+    toggleLights() {
+      this.$dispatch('toggle-lights');
     }
   }
 }

--- a/src/client/style.scss
+++ b/src/client/style.scss
@@ -5,8 +5,11 @@ $muted: #BDBDBD;
 $on: #00C853;
 $on-hover: $on;
 $off: $muted;
-$output-background: #FFFFFF;
-$output-color: $text;
+$output-background-white: #FFFFFF;
+$output-color-white: $text;
+
+$output-background-black: $text;
+$output-color-black: $hover;
 
 [v-cloak] {
   display: none;
@@ -83,14 +86,28 @@ tr {
   font-family: monospace;
   font-size: 14px;
   word-break: break-all;
-  background: $output-background;
-  color: $output-color;
   border-left: 1px solid #EEE;
   position: absolute;
   left: 360px;
   right: 0;
   top: 0;
   bottom: 0;
+
+  &.white {
+    background: $output-background-white;
+    color: $output-color-white;
+  }
+
+  &.black {
+    background: $output-background-black;
+    color: $output-color-black;
+  }
+}
+
+.toggle-background {
+  position: fixed;
+  right: 20px;
+  top: 10px;
 }
 
 // footer

--- a/src/daemon/events/index.js
+++ b/src/daemon/events/index.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const connectSSE = require('connect-sse')
-const stripAnsi = require('strip-ansi')
+const ansiUp = require('ansi_up')
 const sse = connectSSE()
 
 module.exports = (servers) => {
@@ -22,7 +22,7 @@ module.exports = (servers) => {
 
     function sendOutput (data) {
       res.json({
-        output: stripAnsi(data.toString())
+        output: ansiUp.ansi_to_html(data.toString())
       })
     }
 


### PR DESCRIPTION
I took the suggestion from @kbariotis on https://github.com/typicode/hotel/issues/65 to use ansi_up. I'm trusting that it does what it says, and strips out unsafe characters, because I'm using triple `{{{ }}}` to set the inner HTML.

It works!

![screen shot 2016-04-07 at 12 16 08](https://cloud.githubusercontent.com/assets/126989/14349376/8cb1ff78-fcba-11e5-8c50-c211848743f3.png)
