### PR TITLE
add 'remove' alias for 'rm'

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -13,7 +13,7 @@ module.exports = (processArgv) => {
     .help('help').alias('h', 'help')
     .usage('Usage: $0 <command> [options]')
     .command('add [-n name] [-o file] [-e env] [-p port] <cmd>', 'Add server')
-    .command('rm [name]', 'Remove server')
+    .command('rm [name]', 'Remove server').alias('remove', 'rm')
     .command('ls', 'List servers')
     .command('start', 'Start daemon')
     .command('stop', 'Stop daemon')


### PR DESCRIPTION
i've been confused by this several times now. i think it'd be better to have both `rm` and `remove` work, since you'd usually think of `remove` when wanting to remove a server.

even better would be if `rm` was an alias of `remove`, it's just more instinctive
