### PR TITLE
Fix ES6 syntax that was breaking index.js

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -4,5 +4,5 @@ var sudoBlock = require('sudo-block')
 var pkg = require('../package.json')
 
 sudoBlock('\nShould not be run as root, please retry without sudo.\n')
-updateNotifier({ pkg }).notify()
+updateNotifier({ pkg: pkg }).notify()
 require('../lib/cli')(process.argv)


### PR DESCRIPTION
Resolves #110 

This PR:
- Changes the ES6 syntax to ES5 object notation