### PR TITLE
Front-End Updates

### DIFF
--- a/src/daemon/public/index.html
+++ b/src/daemon/public/index.html
@@ -25,6 +25,7 @@
 ~/app$ hotel add http://192.16.1.2:3000</code></pre>
         </div>
         <ul>
+          <!-- TODO: VUE 2.0 - (value, key, index) in obj -->
           <li v-for="(id, item) in monitors | orderBy id">
             <div class="{{item.status}}">
               <a
@@ -52,6 +53,7 @@
               <i class="ion-chevron-right"></i>
             </label>
           </li>
+          <!-- TODO: VUE 2.0 - (value, key, index) in obj -->
           <li v-for="(id, item) in proxies | orderBy id">
             <div>
               <a
@@ -71,6 +73,7 @@
         </footer>
       </aside>
       <!-- output -->
+      <!-- TODO: CONVERT EL TO REFS FOR 2.0 -->
       <main
         v-el:output
         v-on:scroll="onScroll"
@@ -82,6 +85,7 @@
           <div v-if="output.length === 0">
             # No output
           </div>
+          <!-- VUE 2.0 - (value, index) in arr -->
           <div
             v-for="item in output"
             track-by="uid">

--- a/src/daemon/public/index.html
+++ b/src/daemon/public/index.html
@@ -12,7 +12,7 @@
     <div id="app" v-cloak>
       <!-- list -->
       <aside>
-        <div class="container" v-show="isListEmpty">
+        <div class="container fade-in" v-show="isListFetched && isListEmpty">
           <p>
             Congrats!<br>
             You're successfully running hotel.
@@ -26,7 +26,7 @@
         </div>
         <ul>
           <!-- TODO: VUE 2.0 - (value, key, index) in obj -->
-          <li v-for="(id, item) in monitors | orderBy id">
+          <li class="fade-in" v-for="(id, item) in monitors | orderBy id">
             <div class="{{item.status}}">
               <a
                 href="{{href(id)}}"

--- a/src/daemon/public/style.css
+++ b/src/daemon/public/style.css
@@ -1,5 +1,8 @@
 body {
-  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont,
+    "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans",
+    "Droid Sans", "Helvetica Neue", sans-serif;
   color: #212121;
   padding: 0;
   margin: 0;

--- a/src/daemon/public/style.css
+++ b/src/daemon/public/style.css
@@ -118,3 +118,30 @@ input[type=radio] + i {
 input:checked[type=radio] + i {
   color: #212121;
 }
+
+// ANIMATE ASIDE ITEMS
+@-webkit-keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.fade-in {
+  animation-name: fade-in;
+  animation-duration: 0.2s;
+  animation-fill-mode: both;
+}

--- a/src/front/index.js
+++ b/src/front/index.js
@@ -119,6 +119,7 @@ new Vue({ // eslint-disable-line
     },
     scrollToBottom () {
       this.outputScroll = true
+      // TODO: CONVERT EL TO REFS FOR 2.0
       this.$els.output.scrollTop = this.$els.output.scrollHeight
     }
   },

--- a/src/front/index.js
+++ b/src/front/index.js
@@ -26,7 +26,8 @@ new Vue({ // eslint-disable-line
     selected: null,
     outputs: {},
     outputScroll: true,
-    target
+    target,
+    isListFetched: false
   },
   created () {
     this.watchList()
@@ -42,6 +43,7 @@ new Vue({ // eslint-disable-line
       if (window.EventSource) {
         new EventSource('/_/events').onmessage = (event) => {
           Vue.set(this, 'list', JSON.parse(event.data))
+          Vue.set(this, 'isListFetched', true)
         }
       } else {
         setInterval(() => {


### PR DESCRIPTION
Starting a PR to document everything from #124 

- [x] Update deprecated methods
- [x] List flag `isListFetched` for controlling state of aside
- [x] Control hotel install info with `isListFetched`

In 558e2e3 I just documented the areas I saw that will need to be converted over, but not yet deprecated for 1.0. Everything else looks to be safe to convert over. [Here's](https://github.com/vuejs/vue/issues/2873) the 2.0 current final changes.

767a214 adds the `isListFetched` Vue variable, fade in list items or hotel detailed info.

a3b648f adds a conversion to the system font stack to see if you like.

I think the fade-in cleans up the transition a little better for both the list items and the info. The only true way to get the elements to display exactly would be server-side rendering.

You mentioned updating to a UI library. Was there anything you had in mind? I think the only problem with adding a library is there would be another step to trim down on the unused selectors that comes with one.