### PR TITLE
Add X-Forwarded-Proto header for ssl proxy

### DIFF
--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -44,6 +44,7 @@ const proxy = httpProxy.createServer({
 
 // See https://github.com/typicode/hotel/pull/61
 proxy.on('proxyReq', (proxyReq, req) => {
+  proxyReq.setHeader('X-Forwarded-Proto', 'https')
   req._proxyReq = proxyReq
 })
 


### PR DESCRIPTION
Backend application usualy use this header to determine protocal being
used at browser. Althought it's not part of the standard but it's a
defactor practise already.

* WikiPedia: <del>https://en.wikipedia.org/wiki/X-Forwarded-For</del> ( sorry that's a wrong link,  https://en.wikipedia.org/wiki/List_of_HTTP_header_fields )
* Ruby on Rails: https://github.com/josh/rack-ssl/blob/master/lib/rack/ssl.rb

Without this patch setting `force_ssl = true` in a Rails application will cause infinite redirection loop