### PR TITLE
fix: Click on chevron won't open log, in safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "ava && standard",
-    "start": "npm run nodemon & npm run webpack -- --watch & wait",
+    "start": "npm run nodemon & npm run webpack -- --watch -d & wait",
     "prepublish": "npm run build",
     "uninstall": "node bin/uninstall.js",
     "precommit": "npm test",

--- a/src/daemon/public/index.html
+++ b/src/daemon/public/index.html
@@ -49,14 +49,14 @@
               <i :class="isRunning(id) ? 'ion-toggle-filled' : 'ion-toggle'"></i>
             </label>
 
-            <label>
-              <input
-                type="radio"
-                v-model="selected"
-                :value="id"
-                @click="select(id)">
+            
+            <span
+              v-model="selected"
+              :value="id"
+              :class="(selected===id) ? 'chevron selected' : 'chevron'"
+              @click="select(id)">
               <i class="ion-chevron-right"></i>
-            </label>
+            </span>
           </li>
           <li v-for="(item, id) in proxies">
             <div>

--- a/src/daemon/public/style.css
+++ b/src/daemon/public/style.css
@@ -122,13 +122,17 @@ input:checked[type=checkbox] + i {
   color: #14B8CC;
 }
 
-input[type=radio] + i {
+.chevron {
+  display: block;
+  cursor: pointer;
+  color: #CECECE;
+  padding: 10px;
+  font-size: 24px;
   font-size: 14px;
 }
-
-input:checked[type=radio] + i {
-  color: #212121;
-}
+  .chevron.selected {
+    color: #212121;
+  }
 
 // ANIMATE ASIDE ITEMS
 @-webkit-keyframes fade-in {

--- a/src/front/index.js
+++ b/src/front/index.js
@@ -23,7 +23,7 @@ const target = window.location.hash === '#menu'
   : ''
 
 // Template can be found in daemon/public/index.html
-new Vue({ // eslint-disable-line
+let vueApp =  new Vue({ // eslint-disable-line
   el: '#app',
   data: {
     list: {},


### PR DESCRIPTION
the problem was that a radio input was being used inside a label
chrome takes a click on the outer label and propagates it to the
input, safari doesn't.