### PR TITLE
Add examples for `rm`

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -70,6 +70,8 @@ module.exports = (processArgv) => {
     .example('$0 add \'cmd -p $PORT\' --name app')
     .example('$0 add \'cmd -p $PORT\' --env PATH')
     .example('$0 add http://192.168.1.10 -n app ')
+    .example('$0 rm')
+    .example('$0 rm -n app')
     .epilog('https://github.com/typicode/hotel')
     .demand(1)
     .strict()


### PR DESCRIPTION
I had to dig through the code to see how to delete servers with custom names. This wasn't in the readme either. Let me know if I also should update it as well.

Apparently, `hotel rm <server>` doesn't work; the `name` option has to be used (`hotel rm -n <server>`). Maybe we could accept `hotel rm <server>`, and leave `hotel rm -n <server>` for backwards compatibility (haha I'm not really sure what I'm talking about).
