### PR TITLE
Don't die when listing misnamed or malformed files

### DIFF
--- a/src/cli/servers.js
+++ b/src/cli/servers.js
@@ -137,13 +137,23 @@ function ls () {
     .map((file) => {
       const id = path.basename(file, '.json')
       const serverFile = getServerFile(id)
-      const server = JSON.parse(fs.readFileSync(serverFile))
-      if (server.cmd) {
+      let server
+
+      try {
+        server = JSON.parse(fs.readFileSync(serverFile))
+      } catch (error) {
+        // Ignore mis-named or malformed files
+      }
+
+      if (!server) {
+        return null
+      } else if (server.cmd) {
         return `${id}\n${chalk.gray(tildify(server.cwd))}\n${chalk.gray(server.cmd)}`
       } else {
         return `${id}\n${chalk.gray(server.target)}`
       }
     })
+    .filter((item) => item)
     .join('\n\n')
 
   console.log(list)

--- a/test/cli/servers.js
+++ b/test/cli/servers.js
@@ -171,3 +171,13 @@ test('ls', (t) => {
   cli(['', '', 'ls'])
   sinon.assert.calledOnce(servers.ls)
 })
+
+test('ls should ignore non-json files', (t) => {
+  const name = '.DS_Store'
+  const file = path.join(serversDir, `${name}`)
+  fs.writeFileSync(file, '')
+
+  t.notThrows(() => {
+    console.log(cli(['', '', 'ls']))
+  })
+})


### PR DESCRIPTION
I opened `~/.hotel/servers` in Finder. Then when I tried to `hotel ls` it puked on the `.DS_Store` file that had been created.

This PR makes ls robust against misnamed or malformed files.