### PR TITLE
Enable view template caching

### DIFF
--- a/src/daemon/app.js
+++ b/src/daemon/app.js
@@ -29,6 +29,7 @@ module.exports = (group) => {
   // Templates
   app.set('views', path.join(__dirname, 'views'))
   app.set('view engine', 'pug')
+  app.enable('view cache')
   app.locals.pretty = true
 
   // Server-sent events for servers


### PR DESCRIPTION
This change caches view templates in memory:

```bash
# Current
$ time curl -s localhost:2000 >/dev/null
real	0m0.058s

# After change
$ time curl -s localhost:2000 >/dev/null
real	0m0.021s
```

Alternatively, this can be enabled by setting `NODE_ENV=production` but I couldn't figure out how to generate a plist with the environment variable.