### PR TITLE
Add Hotelier to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ To override a value, simply add it to `~/.hotel/conf.json` and run `hotel stop &
 
 ## Third-party tools
 
+* [Hotelier](https://github.com/macav/hotelier) Hotelier (Mac & Windows Tray App)
 * [Hotel Clerk](https://github.com/therealklanni/hotel-clerk) OS X menubar
 * [HotelX](https://github.com/djyde/HotelX) Another OS X menubar (only 1.6MB)
 * [alfred-hotel](https://github.com/exah/alfred-hotel) Alfred 3 workflow


### PR DESCRIPTION
Hello, I created a tray app and tested it on Mac and Windows, which adds a tray icon and let's simply manage the servers from there - https://github.com/macav/hotelier .

I tried the other two menubar apps, but they work only on Mac as far as I know, and actually don't work properly at all (they don't seem to be maintained actively anymore). 
I plan to work on this actively and keep it up to date, as I'm using Hotel in my daily work too. 

Would be great if you could list it in the README under Third-party apps.

Thanks!