### PR TITLE
Fix Menu height (overflow)

### DIFF
--- a/src/app/components/Nav/index.css
+++ b/src/app/components/Nav/index.css
@@ -15,6 +15,7 @@ header {
 
 .menu {
   flex: 1;
+  overflow-y: scroll;
 }
 
 .menu.hidden {


### PR DESCRIPTION
When you've got many servers the menu keeps growing making the UI buggy.
This fixes it by making the menu scrollable when the size of it becomes bigger than the window height.