### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,11 @@ hotel add 'python -m SimpleHTTPServer $PORT'           # static file server (Pyt
 hotel add 'php -S 127.0.0.1:$PORT'                     # PHP
 hotel add 'docker-compose up'                          # docker-compose
 hotel add 'python manage.py runserver 127.0.0.1:$PORT' # Django
+hotel add 'yarn serve --port $PORT' --change-origin    # Vue
 # ...
 ```
+
+Note: `--change-origin` option is required for any application using `webpack-dev-server`. It basically rewrites the `Host` of the request to match the host and port that the server is listening on.
 
 On __Windows__ use `"%PORT%"` instead of `'$PORT'`
 


### PR DESCRIPTION
This update provides additional information about `--change-origin` option which is necessary for apps using `webpack-dev-server` (very common these days).

Without this option, it throws `Invalid Host header` error. Since I found similar issue (https://github.com/typicode/hotel/issues/238) by chance, I thought it would be good to make that information explicit.