### PR TITLE
Minor change to the `add` command ouput.

### DIFF
--- a/src/cli/servers.js
+++ b/src/cli/servers.js
@@ -96,7 +96,7 @@ function add(param, opts = {}) {
 
   const data = JSON.stringify(conf, null, 2)
 
-  console.log(`Create ${tildify(file)}`)
+  console.log(`Created ${tildify(file)}`)
   fs.writeFileSync(file, data)
 
   // if we're mapping a domain to a URL there's no additional info to output


### PR DESCRIPTION
When log prints `Create`, it seems like it is asking the user to "Create" the file. But the file is already created. So it may make sense for the log to say "Created" (So that it is unambigious)