### PR TITLE
Add support for proxying to server address

### DIFF
--- a/src/daemon/routers/index.js
+++ b/src/daemon/routers/index.js
@@ -8,9 +8,9 @@ module.exports = function(group) {
   function pac(req, res) {
     log('Serve proxy.pac')
     if (conf.proxy) {
-      res.render('proxy-pac-with-proxy', { conf })
+      res.render('proxy-pac-with-proxy', { conf, hostname: req.hostname })
     } else {
-      res.render('proxy-pac', { conf })
+      res.render('proxy-pac', { conf, hostname: req.hostname })
     }
   }
 

--- a/src/daemon/views/proxy-pac-with-proxy.pug
+++ b/src/daemon/views/proxy-pac-with-proxy.pug
@@ -5,7 +5,7 @@
   // See also https://en.wikipedia.org/wiki/Private_network
   function FindProxyForURL (url, host) {
     if (dnsDomainIs(host, '.#{conf.tld}')) {
-      return 'PROXY 127.0.0.1:#{conf.port}';
+      return 'PROXY #{hostname}:#{conf.port}';
     }
 
     var address = dnsResolve(host);

--- a/src/daemon/views/proxy-pac.pug
+++ b/src/daemon/views/proxy-pac.pug
@@ -3,7 +3,7 @@
   // Configuration file can be found in ~/.hotel
   function FindProxyForURL (url, host) {
     if (dnsDomainIs(host, '.#{conf.tld}')) {
-      return 'PROXY 127.0.0.1:#{conf.port}';
+      return 'PROXY #{hostname}:#{conf.port}';
     }
 
     return 'DIRECT';


### PR DESCRIPTION
This is a simple feature to add support for proxying to the server address being specified. Currently this is only being restricted in the `proxy.pac` to just `127.0.0.1` and there is no real reason why it can't be substituted dynamically via the request host.

I test inside VMs and this is beneficial to be able to just point the local VM to the proxy on the host without manually creating a modified copy.