### PR TITLE
Forwards to local services regardless of path and REST method, and can proxy them rather than redirect

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -40,6 +40,11 @@ const addOptions = {
     default: false,
     boolean: true
   },
+  'forward-by-proxy': {
+    describe: 'Proxies requests to this server rather than forwarding',
+    default: false,
+    boolean: true
+  },
   dir: {
     describe: 'Server directory',
     string: true

--- a/src/cli/servers.js
+++ b/src/cli/servers.js
@@ -59,6 +59,10 @@ function add(param, opts = {}) {
     conf.httpProxyEnv = opts.httpProxyEnv
   }
 
+  if (opts.forwardByProxy) {
+    conf.mechanism = 'proxy'
+  }
+
   if (isUrl(param)) {
     conf = {
       target: param,

--- a/src/conf.js
+++ b/src/conf.js
@@ -11,6 +11,7 @@ const defaults = {
   host: '127.0.0.1',
   timeout: 5000,
   tld: 'localhost',
+  mechanism: 'redirect',
   // Replace with your network proxy IP (1.2.3.4:5000) if any
   // For example, if you're behind a corporate proxy
   proxy: false

--- a/src/daemon/group.js
+++ b/src/daemon/group.js
@@ -87,6 +87,14 @@ class Group extends EventEmitter {
       }
     }
 
+    if (conf.mechanism) {
+      log(`adding env.mechanism:${conf.mechanism}`)
+      conf.env = {
+        mechanism: conf.mechanism,
+        ...conf.env
+      }
+    }
+
     let logFile
     if (conf.out) {
       logFile = path.resolve(conf.cwd, conf.out)
@@ -327,8 +335,14 @@ class Group extends EventEmitter {
     // Make sure to send only one response
     const send = once(() => {
       let target = item.target + (item.target.endsWith('/') ? '' : '/') + path
-      log(`Redirect - ${id} → ${target}`)
-      res.redirect(307, target)
+      if (item.env && item.env.mechanism === 'proxy') {
+        let target = item.target + (item.target.endsWith('/') ? '' : '/') + path
+        log(`Proxy - ${id} → ${target}`)
+        this.proxyWeb(req, res, target)
+      } else {
+        log(`Redirect - ${id} → ${target}`)
+        res.redirect(307, target)
+      }
     })
 
     if (item.start) {

--- a/src/daemon/group.js
+++ b/src/daemon/group.js
@@ -322,17 +322,14 @@ class Group extends EventEmitter {
   redirect(req, res) {
     const { id } = req.params
     const { item } = req.hotel
-    let target = item.target;
     let path = req.params[0] || ''
-
-
-    target = (target.endsWith('/') ? ''  : '/') + path;
 
     // Make sure to send only one response
     const send = once(() => {
-      log(`Redirect - ${id} → ${target}`);
-      res.redirect(307, target);
-    });    
+      let target = item.target + (item.target.endsWith('/') ? '' : '/') + path
+      log(`Redirect - ${id} → ${target}`)
+      res.redirect(307, target)
+    })
 
     if (item.start) {
       // Set target

--- a/src/daemon/group.js
+++ b/src/daemon/group.js
@@ -326,7 +326,7 @@ class Group extends EventEmitter {
     // Make sure to send only one response
     const send = once(() => {
       log(`Redirect - ${id} → ${item.target}`)
-      res.redirect(item.target)
+      res.redirect(307, item.target)
     })
 
     if (item.start) {

--- a/src/daemon/group.js
+++ b/src/daemon/group.js
@@ -322,12 +322,17 @@ class Group extends EventEmitter {
   redirect(req, res) {
     const { id } = req.params
     const { item } = req.hotel
+    let target = item.target;
+    let path = req.params[0] || ''
+
+
+    target = (target.endsWith('/') ? ''  : '/') + path;
 
     // Make sure to send only one response
     const send = once(() => {
-      log(`Redirect - ${id} → ${item.target}`)
-      res.redirect(307, item.target)
-    })
+      log(`Redirect - ${id} → ${target}`);
+      res.redirect(307, target);
+    });    
 
     if (item.start) {
       // Set target

--- a/src/daemon/routers/index.js
+++ b/src/daemon/routers/index.js
@@ -17,7 +17,7 @@ module.exports = function(group) {
   router
     .get('/proxy.pac', pac)
     .all(
-      '/:id',
+      '/:id/*',
       group.exists.bind(group),
       group.start.bind(group),
       group.redirect.bind(group)

--- a/src/daemon/routers/index.js
+++ b/src/daemon/routers/index.js
@@ -16,7 +16,7 @@ module.exports = function(group) {
 
   router
     .get('/proxy.pac', pac)
-    .get(
+    .all(
       '/:id',
       group.exists.bind(group),
       group.start.bind(group),

--- a/src/daemon/routers/index.js
+++ b/src/daemon/routers/index.js
@@ -17,7 +17,7 @@ module.exports = function(group) {
   router
     .get('/proxy.pac', pac)
     .all(
-      '/:id/*',
+      ['/:id', '/:id/*'],
       group.exists.bind(group),
       group.start.bind(group),
       group.redirect.bind(group)

--- a/test/cli/servers.js
+++ b/test/cli/servers.js
@@ -66,6 +66,7 @@ test('add should support options', t => {
     env[1],
     '-x',
     '--co',
+    '--forward-by-proxy',
     '--http-proxy-env'
   ])
 
@@ -82,6 +83,7 @@ test('add should support options', t => {
     },
     xfwd: true,
     changeOrigin: true,
+    mechanism: 'proxy',
     httpProxyEnv: true
   }
 

--- a/test/daemon/app.js
+++ b/test/daemon/app.js
@@ -245,7 +245,7 @@ test.cb('GET http://localhost:2000/node should redirect to node server', t => {
     .get('/node')
     .set('Host', 'localhost')
     .expect('location', /http:\/\/localhost:51234/)
-    .expect(302, t.end)
+    .expect(307, t.end)
 })
 
 test.cb(
@@ -257,7 +257,7 @@ test.cb(
     request(app)
       .get('/node')
       .expect('location', /http:\/\/127.0.0.1:51234/)
-      .expect(302, t.end)
+      .expect(307, t.end)
   }
 )
 
@@ -267,7 +267,7 @@ test.cb('GET http://localhost:2000/proxy should redirect to target', t => {
     .get('/proxy')
     .set('Host', 'localhost')
     .expect('location', /http:\/\/localhost:4000/)
-    .expect(302, t.end)
+    .expect(307, t.end)
 })
 
 //

--- a/test/daemon/app.js
+++ b/test/daemon/app.js
@@ -270,6 +270,8 @@ test.cb('GET http://localhost:2000/proxy should redirect to target', t => {
     .expect(307, t.end)
 })
 
+// TODO: Add tests for forward-by-proxy cases
+
 //
 // Test daemon/app.js
 //


### PR DESCRIPTION
Resolves Issue https://github.com/typicode/hotel/issues/350.

I have an interest in using hotel to manage not just UI servers, but also RESTful services as well. In order to do that effectively, we need to be able to accept multiple REST methods, not just GET, and be able to serve paths beyond just the root.

Unfortunately, most clients do not deal with redirects on non-GET methods particularly well (though the change https://github.com/christianwerz made to switch the redirect to a 307 does help some clients). Because of that, I've also added the ability to specify a `--forward-by-proxy` option when doing an `add` which will tell the router to proxy the request directly, rather than returning a redirect.