### PR TITLE
Mention in README that hotel auto-starts on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can view the list of Supporters here https://thanks.typicode.com.
 * __Proxy__ - Map local domains to remote servers
 * __System-friendly__ - No messing with `port 80`, `/etc/hosts`, `sudo` or additional software
 * Fallback URL - `http://localhost:2000/project`
+* Hotel automatically starts on login
 * Servers are only started when you access them
 * Plays nice with other servers (Apache, Nginx, ...)
 * Random or fixed ports


### PR DESCRIPTION
As a user, I was very surprised to discover this!  For example, it means that if you want your hotel server to have some environment variable set, `MY_VAR=... hotel start` won't work.  (Actually, on linux, it will work the first time, and then not subsequently.  From reading the source, I think on mac it will never work, but I haven't tested.)  Anyways, it seems like a useful thing to document.  I even called it a feature ;-) .