### PR TITLE
Add an option to not run hotel on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,10 @@ By default, `hotel` uses the following configuration values:
   "tld": 'localhost', 
   
   // If you're behind a corporate proxy, replace this with your network proxy IP (example: "1.2.3.4:5000")
-  "proxy": false
+  "proxy": false,
+
+  // Change to false to prevent hotel from starting itself up automatically on login
+  "autostart": true
 }
 ```
 

--- a/src/conf.js
+++ b/src/conf.js
@@ -13,7 +13,9 @@ const defaults = {
   tld: 'localhost',
   // Replace with your network proxy IP (1.2.3.4:5000) if any
   // For example, if you're behind a corporate proxy
-  proxy: false
+  proxy: false,
+  // Set to false to disable automatic running on startup.
+  autostart: true
 }
 
 // Create empty conf it it doesn't exist


### PR DESCRIPTION
This default is surely useful for many people, but it's not right for
me: I have many projects on my computer, and I only want to start hotel
if I'm working on certain ones.  Now there's an option to disable that
behavior.  I cribbed what it does from user-startup, minus the startup
parts.

See also #356.