### PR TITLE
Fix ERR_INVALID_ARG_TYPE exception in call to writeFileSync()

### DIFF
--- a/src/pid-file.js
+++ b/src/pid-file.js
@@ -9,7 +9,7 @@ module.exports = {
 
 function create() {
   console.log('create', pidFile, process.pid)
-  return fs.writeFileSync(pidFile, process.pid)
+  return fs.writeFileSync(pidFile, `${process.pid}`)
 }
 
 function read() {


### PR DESCRIPTION
Running on MacOS 10.15.7 (Catalina)

Originally I installed and ran Hotel like this:

```
chown -R moxley:admin /usr/local/lib/node_modules
npm install -g hotel
hotel start
```

No errors were returned, and when I tried to access the hotel HTTP service, nothing was listening:

```
$ curl localhost:2000
curl: (7) Failed to connect to localhost port 2000: Connection refused
```

This matches the behavior described in #344.

Next, I cloned the hotel repo, and ran it like this:

```
npm i
npm start
```

The following error showed up in the server output:

```
15:16:55 - Watching /Users/moxley/.hotel/servers
create /Users/moxley/.hotel/daemon.pid 3609
internal/fs/utils.js:779
  throw new ERR_INVALID_ARG_TYPE(
  ^

TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (3609)
    at Object.writeFileSync (fs.js:1460:5)
    at Object.create (/usr/local/lib/node_modules/hotel/lib/pid-file.js:18:13)
    at Object.<anonymous> (/usr/local/lib/node_modules/hotel/lib/daemon/index.js:20:9)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'ERR_INVALID_ARG_TYPE'
```

After editing src/pid-file.js, converting the numeric port to a string, the service ran without errors.