### PR TITLE
chore: bump http-proxy 1.17.0 to 1.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "exit-hook": "^1.1.1",
     "express": "^4.16.2",
     "get-port": "^3.2.0",
-    "http-proxy": "^1.17.0",
+    "http-proxy": "^1.18.1",
     "matcher": "^1.1.0",
     "mkdirp": "^0.5.1",
     "once": "^1.3.2",


### PR DESCRIPTION
The http-proxy dependency was pinned at ^1.17.0, which predates the 1.18.x line released in 2020 that fixed minor correctness and compatibility issues. Bumping the lower bound to ^1.18.1 ensures 
pm install resolves to the latest stable release in the 1.x line rather than potentially locking to 1.17.0 in edge-case environments.

This is a minor version bump and is fully backwards-compatible per semantic versioning; the http-proxy 1.x public API is unchanged between 1.17 and 1.18. No application code needed modification.

All existing tests pass - va and eslint continue to succeed with the updated dependency.